### PR TITLE
apply header fix found by @sonygod

### DIFF
--- a/linc/linc_lua.h
+++ b/linc/linc_lua.h
@@ -1,7 +1,9 @@
 #pragma once
 
-//hxcpp include should always be first    
+//hxcpp include should always be first
+#ifndef HXCPP_H
 #include <hxcpp.h>
+#endif
 #include <hx/CFFI.h>
 
 //include other library includes as needed


### PR DESCRIPTION
I found that the fix @sonygod proposed in #1 was necessary for me to get hxvm-lua compiling with this with haxe 4.3.1 and hxcpp 4.3.2, so I applied it in a branch of a fork for myself. If it's a good change, maybe it can be merged in.